### PR TITLE
资产明细页面时间显示不正确

### DIFF
--- a/src/components/AssetCard.vue
+++ b/src/components/AssetCard.vue
@@ -17,7 +17,8 @@ export default {
   props: ['asset'],
   computed: {
     friendlyDate() {
-      return moment(this.asset.timestamp).fromNow();
+      // 数据采用了+0时区 中国是+8时区 则减去八小时
+      return moment(this.asset.timestamp).subtract(8, 'hours').fromNow();
     },
   },
   created() {


### PR DESCRIPTION
数据采用了+0时区 中国是+8时区 则减去八小时