### PR TITLE
sign-dev.dravatar.xyz 暂时改回使用 development build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           root: ~/repo/
           paths:
             - dist
-  deploy-testing:
+  deploy-staging:
     <<: *defaults
     steps:
       - attach_workspace: 
@@ -65,7 +65,7 @@ jobs:
             sudo npm i -g surge          
             cd ./dist/dist/
             mv index.html 200.html # workaround for spa history router
-            surge --project ./ --domain testing.smartsignature.io
+            surge --project ./ --domain staging.smartsignature.io
 workflows:
   version: 2
   build-test:
@@ -76,13 +76,14 @@ workflows:
               ignore:
                 - /master/
                 - /testing/
-  build-and-deploy-testing:
+  #暂定用 testing 分支的内容 未来可能开一个 staging 分支？
+  build-and-deploy-staging:
     jobs:
       - build:
           filters:
             branches:
-              only: /testing/
-      - deploy-testing:
+              only: /testing/ 
+      - deploy-staging:
           requires:
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       # run builds!
       - run: 
           name: Build
-          command: yarn run build-for-surge
+          command: yarn run build-prod
 
       - store_artifacts:
           path: ~/repo/dist
@@ -64,11 +64,11 @@ jobs:
           command: |
             sudo npm i -g surge          
             cd ./dist/dist/
-            mv index.html 200.html # workaround for spa history router
+            mv ./index.html ./200.html
             surge --project ./ --domain staging.smartsignature.io
 workflows:
   version: 2
-  build-test:
+  "Build test":
     jobs:
       - build:
           filters:
@@ -77,7 +77,7 @@ workflows:
                 - /master/
                 - /testing/
   #暂定用 testing 分支的内容 未来可能开一个 staging 分支？
-  build-and-deploy-staging:
+  "Build and Deploy to staging":
     jobs:
       - build:
           filters:
@@ -88,4 +88,4 @@ workflows:
             - build
           filters:
             branches:
-              only: /testing/
+              only: /testing/ 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build-dev": "vue-cli-service build --mode development",
     "build-prod": "vue-cli-service build --mode production",
     "lint": "vue-cli-service lint",
-    "build-for-netlify": "npm run build-prod && npm run fix-netlify-cs-routing",
+    "build-for-netlify": "npm run build-dev && npm run fix-netlify-cs-routing",
     "build-for-surge": "npm run build-prod && npm run fix-surge-cs-routing",
     "fix-netlify-cs-routing": "echo '/*    /index.html   200' >> ./dist/_redirects",
     "fix-surge-cs-routing": "mv ./dist/index.html ./dist/200.html"

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
     "build-prod": "vue-cli-service build --mode production",
     "lint": "vue-cli-service lint",
     "build-for-netlify": "npm run build-dev && npm run fix-netlify-cs-routing",
-    "build-for-surge": "npm run build-prod && npm run fix-surge-cs-routing",
-    "fix-netlify-cs-routing": "echo '/*    /index.html   200' >> ./dist/_redirects",
-    "fix-surge-cs-routing": "mv ./dist/index.html ./dist/200.html"
+    "fix-netlify-cs-routing": "echo '/*    /index.html   200' >> ./dist/_redirects"
   },
   "dependencies": {
     "axios": "^0.18.0",

--- a/src/views/EasterEgg.vue
+++ b/src/views/EasterEgg.vue
@@ -2,11 +2,8 @@
     <div class="easter-egg">
         <h1 class="title">🎉 恭喜你发现了隐藏的彩蛋！</h1>
         <p>当前模式：{{env}}</p>
-        <div class="dev-only" v-if="isDevelopment">
-            <h1 class="title">Development 专有彩蛋</h1>
-            <p>版本号： {{ version }}</p>
-            <p v-if="checkIsBuildOnCommit">基于 Commit {{ commitHash }} 构建</p>
-        </div>
+        <p>版本号： {{ version }}</p>
+        <p v-if="checkIsBuildOnCommit">基于 commit <a :href="commitUrl">{{ commitHash }} </a> 构建</p>
     </div>
 </template>
 
@@ -20,9 +17,6 @@ export default {
     version() {
       return process.env.VUE_APP_VERSION;
     },
-    isDevelopment() {
-      return this.env === 'development';
-    },
     commitHash() {
       return process.env.VUE_APP_COMMIT_HASH;
     },
@@ -31,6 +25,9 @@ export default {
       // Ref: https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli-service/lib/util/resolveClientEnv.js#L1
       return this.commitHash !== 'undefined';
     },
+    commitUrl() {
+      return `https://github.com/smart-signature/smart-signature-future/commit/${this.commitHash}`
+    }
   },
 };
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4370,6 +4370,10 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "http://registry.npm.taobao.org/kind-of/download/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
+konami@^1.6.2:
+  version "1.6.2"
+  resolved "http://registry.npm.taobao.org/konami/download/konami-1.6.2.tgz#022a52efc23ba74c5b457cf2755af71386f28b29"
+
 launch-editor-middleware@^2.2.1:
   version "2.2.1"
   resolved "http://registry.npm.taobao.org/launch-editor-middleware/download/launch-editor-middleware-2.2.1.tgz#e14b07e6c7154b0a4b86a0fd345784e45804c157"


### PR DESCRIPTION
我承认我那天状态不好（吃了药 Code under the influence)，**我的错**

没察觉到 netlify 享受 production build 的好处时，顺便也用上了 production 的后端和合约


这次PR：
* sign-dev.dravatar.xyz 改回使用 development build
* 彩蛋的 commit hash 不再限定于 development build
* https://staging.smartsignature.io/ 应该准备好去 build and serve the production build

现在 Circle-CI 会在 testing 分支（暂定， 未来可能开一个 statging 分支？？ 有待讨论）的基础上
build一个 production build 到 https://staging.smartsignature.io/