### PR TITLE
更新 ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,36 @@
 # Smart Signature Front End
 Sign it if you mean it. Let's Buidl! 🏄
 
-- Live Demo: 🙋👉 [Production](https://smartsignature.io/) | [Stage](https://sign-dev.dravatar.xyz/)
+- Live Demo: 🙋👉 [Production](https://smartsignature.io/) | [Staging](https://staging.smartsignature.io) | [Testing](https://testing.smartsignature.io)
 
-- Other Resources: [Backend Repo](https://github.com/smart-signature/smart-signature-backend) | [Contract](https://github.com/smart-signature/smart-signature-EOS-contract) | [Documentation](https://shimo.im/docs/UOYT3DqklCYBbzny) | [Whitepaper(Draft)](https://hackmd.io/Q3KNkxjgSwKRJ5cfBL2I4g)
+- Other Resources: [Backend Repo](https://github.com/smart-signature/smart-signature-backend) | [Backend Doc](https://github.com/smart-signature/smart-signature-backend/blob/master/doc.md) | [Contract](https://github.com/smart-signature/smart-signature-EOS-contract) | [Documentation about Project](https://shimo.im/docs/UOYT3DqklCYBbzny) | [Whitepaper (Draft)](https://hackmd.io/Q3KNkxjgSwKRJ5cfBL2I4g)
 
 Newcomes are encouraged to checkout our [good first issue](https://github.com/smart-signature/smart-signature-future/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) first. In order to be involved, you must to create your own branch and send pull request to the test branch. [Don't trust, verify](https://www.reddit.com/r/Bitcoin/comments/5ezw5o/dont_trust_verify/). 
 
-新人请从 [good first issue](https://github.com/smart-signature/smart-signature-future/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) 开始。为了能够合并，你需要创建自己的分支并将 pull pequest 发送到 test 分支。[無徵，不信](https://zh.wikisource.org/zh/%E7%A6%AE%E8%A8%98/%E4%B8%AD%E5%BA%B8)。
+新人请从 [good first issue](https://github.com/smart-signature/smart-signature-future/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) 开始。
+
+为了能够合并，你需要创建自己的分支并将 Pull Request 发送到 `testing` 分支。[無徵，不信](https://zh.wikisource.org/zh/%E7%A6%AE%E8%A8%98/%E4%B8%AD%E5%BA%B8)。
+
 
 ## 为什么前端在线预览没有更新？
 
 前端在线预览是实时依据 `testing` 分支实时部署更新的，没有人工干预。
 
-为了加载性能、节省流量、提升用户首屏体验，网站使用了 [Service Worker (服務工作線程)](https://developers.google.cn/web/fundamentals/primers/service-workers/?hl=zh-tw)。部分支持 Service Worker 的浏览器 **会使用你上一次访问网站的缓存**，所以**可能会出现没有更新的感觉**。
+* 如果用的是 testing 版本，可能是浏览器缓存问题。建议清空缓存或在本地 serve。
+
+* 如果用的是 Production 或 Staging 版本，为了加载性能、节省流量、提升用户首屏体验，使用了 [Service Worker (服務工作線程)](https://developers.google.cn/web/fundamentals/primers/service-workers/?hl=zh-tw)。部分支持 Service Worker 的浏览器 **会使用你上一次访问网站的缓存**，所以**可能会出现没有更新的感觉**。
 
 ### 如何知道网站是否在更新并使用最新版本？
-对于不支持 Service Worker 的浏览器，你使用的应该是最新的版本。（即使有部分文件本地缓存，也有一段白屏期）
+对于不支持 Service Worker 的浏览器，你使用的应该是最新的版本。（不排除你用的是浏览器给的历史缓存，建议使用 Konami 秘籍查看版本信息？）
 
-对于支持 Service Worker 的浏览器，浏览器像打开 App 一样**立刻加载**上一次你使用的版本缓存，然后后台会**自动检测更新**。更新成功后，如下图所示，点击刷新按钮即可使用最新版本。
+对于支持 Service Worker 的浏览器，在 Production 或 Staging 版本下，浏览器像打开 App 一样**立刻加载**上一次你使用的版本缓存，然后后台会**自动检测更新**。更新成功后，如下图所示，点击刷新按钮即可使用最新版本。
 
 ![](https://ws3.sinaimg.cn/large/006tKfTcgy1g1d2zjjptqj30gk0hyt96.jpg)
 
 
 ## Project setup
 ```
-npm install # install all dependencies for development
+npm install # 直接 `yarn` 也行，推荐使用 yarn，速度更快
 npm run serve # Compiles and hot-reloads for development
 npm run build-dev # Compiles for development
 npm run build-prod # Compiles and minifies for production


### PR DESCRIPTION
常规文档性质更新，

缘由是原先的 `sign-dev.dravatar.xyz` 快过期了，准备更换域名为 `testing.smartsignature.io`

![image](https://user-images.githubusercontent.com/3261732/55929081-b1660080-5c4d-11e9-9182-05859e7c5b7b.png)


# Merge 前需要做以下操作：

- [x] 解析 `testing.smartsignature.io`
- [x] 测试后端 `apitest.smartsignature.io` 需要加入 `testing.smartsignature.io` 的 CORS 白名单
![image](https://user-images.githubusercontent.com/3261732/55929029-795ebd80-5c4d-11e9-80b6-675ddfc3b3a6.png)

有谁知道谁在控制 `apitest.smartsignature.io` 吗？