### PR TITLE
fix 关注和粉丝列表加载不出来

### DIFF
--- a/src/views/User/FollowList.vue
+++ b/src/views/User/FollowList.vue
@@ -110,9 +110,10 @@ export default {
       this.refreshing = true;
       this.loading = true;
       if (this.activeNameSwipe == '关注') {
-        getFollowList({ username: this.username }, async (error, response, body) => {
-          const list = body.list || [];
-          if (response.statusCode != 200) {
+        getFollowList({ username: this.username }, async ({ error, response }) => {
+          console.log(error, response);
+          const list = response.data.list || [];
+          if (response.status !== 200) {
             this.$Notice.error({
               title: '获取失败',
             });
@@ -128,9 +129,9 @@ export default {
           this.loading = false;
         });
       } else {
-        getFansList({ username: this.username }, async (error, response, body) => {
-          const list = body.list || [];
-          if (response.statusCode != 200) {
+        getFansList({ username: this.username }, async ({ error, response }) => {
+          const list = response.data.list || [];
+          if (response.status !== 200) {
             this.$Notice.error({
               title: '获取失败',
             });


### PR DESCRIPTION
fix 关注和粉丝列表加载不出来

![image](https://user-images.githubusercontent.com/24250627/56186097-d80ea780-6050-11e9-8240-8abe378c5a4b.png)

发现的问题 ps:
1. 无分页
2. 建议把 Avatar userName 一起返回在接口里面，避免造成大量的请求 导致页面长时间显示 加载中

